### PR TITLE
bumped shrinkwrap to 1.2.6, selenium to 1.53.1, added shrinkwrap-descriptors @ 2.0.0.alpha-10 

### DIFF
--- a/arquillian-core/pom.xml
+++ b/arquillian-core/pom.xml
@@ -23,6 +23,13 @@
                 <type>pom</type>
             </dependency>
             <dependency>
+                <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+                <artifactId>shrinkwrap-descriptors-bom</artifactId>
+                <version>${version.shrinkwrap_descriptors}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
                 <groupId>org.jboss.shrinkwrap.resolver</groupId>
                 <artifactId>shrinkwrap-resolver-bom</artifactId>
                 <version>${version.shrinkwrap_resolvers}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,9 +67,10 @@
         <version.arquillian_spacelift>1.0.0.Alpha8</version.arquillian_spacelift>
         <version.arquillian_chameleon>1.0.0.Alpha6</version.arquillian_chameleon>
         <version.arquillian_cukes_in_space>1.6.1</version.arquillian_cukes_in_space>
-        <version.shrinkwrap>1.2.3</version.shrinkwrap>
+        <version.shrinkwrap>1.2.6</version.shrinkwrap>
+        <version.shrinkwrap_descriptors>2.0.0-alpha-10</version.shrinkwrap_descriptors>
         <version.shrinkwrap_resolvers>2.2.2</version.shrinkwrap_resolvers>
-        <version.selenium>2.53.0</version.selenium>
+        <version.selenium>2.53.1</version.selenium>
     </properties>
 
     <modules>


### PR DESCRIPTION
In the parent pom bumped version of shrinkwrap from 1.2.3 to 1.2.6, selenium from 2.53.0 to 2.53.1, added 2.0.0.alpha-10 as version for shrinkwrap_descriptors 
in the core pom explicitly added the shrinkwrap-descriptors bom which wasn't being referenced and the versions were being included as transitive dependencies

have used this configuration successfully with weld embedded, glassfish managed, jboss eap 6.4.0  managed and remote

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arquillian/arquillian-universe-bom/56)

<!-- Reviewable:end -->
