### PR TITLE
Update travis to use openjdk8 as oraclejdk8 is no longer available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 before_install:
   - sed -i.bak -e 's|http://repo.maven.apache.org/maven2|https://repo.maven.apache.org/maven2|g' $HOME/.m2/settings.xml
   - chmod +x mvnw


### PR DESCRIPTION
update travis ci to use openjdk8